### PR TITLE
Create central api service data structure.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -203,7 +203,7 @@ PATH="$PREFIX/libexec/opensearch/bin:\$PATH"
 
 # Install plugin security to be able to disable SSL
 if [ ! -d "\$OPENSEARCH_HOME/plugins/opensearch-security" ];then
-    mkdir -p \$OPENSEARCH_HOME/{plugins,config,config}
+    mkdir -p \$OPENSEARCH_HOME/{plugins,config}
     opensearch-plugin install --batch https://repo1.maven.org/maven2/org/opensearch/plugin/opensearch-security/2.19.1.0/opensearch-security-2.19.1.0.zip
 fi
 mkdir -p \$DATA_DIR \$LOG_DIR

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: e9cf4351b8753571843e6f1ea99121989259cad9e9315ff82e3f69c1af881f84
 
 build:
-  number: 2
+  number: 7
   noarch: python
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: e9cf4351b8753571843e6f1ea99121989259cad9e9315ff82e3f69c1af881f84
 
 build:
-  number: 1
+  number: 2
   noarch: python
 
 


### PR DESCRIPTION
This PR aims to create a centralised and configurable directory structure that can be used for the services to write persistent data. This is important for two reasons:

- service data is not scattered all over the conda environment
- the freva-rest-server docker can simply use one single path to a volume to make all service data persistent.

@mo-dkrz please review

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):



-->

<!--
Please add any other relevant info below:
-->
