### PR TITLE
Fix typo which leads mongo sevice not be started

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -116,9 +116,9 @@ create_mongo_unit(){
     cat << EOF > $PREFIX/libexec/$PKG_NAME/scripts/init-mongo
 #!/usr/bin/env bash
 CONDA_PREFIX=\$(readlink -f \${CONDA_PREFIX:-\$(dirname \$0)../../../)})
-DATA_DIR=\${API_DATA_DIR:-$PREFIX/var/$PKG_NAME/monogodb}
+DATA_DIR=\${API_DATA_DIR:-$PREFIX/var/$PKG_NAME/monogdb}
 LOG_DIR=\${API_LOG_DIR:-$PREFIX/var/log/$PKG_NAME}
-CONFIG_DIR=\${API_CONFIG_DIR:-$PREFIX/share/$PKG_NAME/monogodb}
+CONFIG_DIR=\${API_CONFIG_DIR:-$PREFIX/share/$PKG_NAME/monogdb}
 set  -o nounset -o pipefail -o errexit
 mkdir -p \$LOG_DIR \$DATA_DIR \$CONFIG_DIR
 API_MONGO_HOST=\${API_MONGO_HOST:-localhost:27017}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: e9cf4351b8753571843e6f1ea99121989259cad9e9315ff82e3f69c1af881f84
 
 build:
-  number: 12
+  number: 13
   noarch: python
 
 


### PR DESCRIPTION
This typo doesn't allow the mongo service runs in dockerfile since it cannot find the conf file

```bash
less /var/log/mongodb/mongodb.err.log
Error opening config file '/opt/conda/share/freva-rest-server/mongodb/mongod.yaml': No such file or directory
try '/opt/conda/bin/mongod --help' for more information
```


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
